### PR TITLE
add Laravel TestResponse macros to allow chained http tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,19 +11,25 @@
     "license": "MIT",
     "require": {
         "php": "^7.4",
-        "pestphp/pest": "^0.2",
+        "pestphp/pest": "dev-master",
         "spatie/phpunit-snapshot-assertions": "^4.2.2"
     },
     "autoload": {
         "psr-4": {
-            "Spatie\\Snapshots\\Concerns\\": "./src/Concerns/"
+            "Spatie\\Snapshots\\Concerns\\": "./src/Concerns/",
+            "Spatie\\Snapshots\\Laravel\\": "./src/Laravel/"
         },
         "files": [
             "src/Functions.php"
         ]
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16.3"
+        "friendsofphp/php-cs-fixer": "^2.16.3",
+        "illuminate/support": "^7.0",
+        "illuminate/testing": "^7.0",
+        "orchestra/testbench": "^5.0",
+        "pestphp/pest-plugin-laravel": "^0.2",
+        "fzaninotto/faker": "^1.9"
     },
     "scripts": {
         "test": "pest",
@@ -34,5 +40,12 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\Snapshots\\Laravel\\SnapshotsServiceProvider"
+            ]
+        }
+    }
 }

--- a/src/Laravel/SnapshotsServiceProvider.php
+++ b/src/Laravel/SnapshotsServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Snapshots\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Testing\TestResponse;
+use function Spatie\Snapshots\assertMatchesHtmlSnapshot;
+use function Spatie\Snapshots\assertMatchesJsonSnapshot;
+use function Spatie\Snapshots\assertMatchesSnapshot;
+use function Spatie\Snapshots\assertMatchesTextSnapshot;
+use function Spatie\Snapshots\assertMatchesXmlSnapshot;
+use Spatie\Snapshots\Driver;
+
+class SnapshotsServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        TestResponse::macro('assertMatchesSnapshot', function (Driver $driver = null) {
+            /** @var TestResponse $this */
+            assertMatchesSnapshot($this->getContent(), $driver);
+        });
+
+        TestResponse::macro('assertMatchesHtmlSnapshot', function () {
+            /** @var TestResponse $this */
+            assertMatchesHtmlSnapshot($this->getContent());
+        });
+
+        TestResponse::macro('assertMatchesJsonSnapshot', function () {
+            /** @var TestResponse $this */
+            assertMatchesJsonSnapshot($this->getContent());
+        });
+
+        TestResponse::macro('assertMatchesTextSnapshot', function () {
+            /** @var TestResponse $this */
+            assertMatchesTextSnapshot($this->getContent());
+        });
+
+        TestResponse::macro('assertMatchesXmlSnapshot', function () {
+            /** @var TestResponse $this */
+            assertMatchesXmlSnapshot($this->getContent());
+        });
+    }
+}

--- a/tests/Laravel.php
+++ b/tests/Laravel.php
@@ -1,0 +1,74 @@
+<?php
+
+use Faker\Factory;
+use Illuminate\Support\Facades\Route;
+use Spatie\Snapshots\Drivers\YamlDriver;
+use Spatie\Snapshots\Laravel\SnapshotsServiceProvider;
+
+class TestCase extends Orchestra\Testbench\TestCase
+{
+    public function getPackageProviders($app)
+    {
+        return [
+            SnapshotsServiceProvider::class,
+        ];
+    }
+}
+
+uses(TestCase::class);
+
+$faker = Factory::create();
+
+beforeEach(function () use ($faker) {
+    Route::get('html', function () {
+        return trim(<<<HTML
+            <!DOCTYPE html>
+            <html lang="en"><head><title>title</title></head><body><h1>first headline</h1></body></html>
+        HTML);
+    });
+    Route::get('json', function () {
+        return [
+            'foo' => 'bar',
+            'ping' => 'pong',
+        ];
+    });
+    Route::get('xml', function () {
+        return trim(<<<XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <list>
+            <item>item #1</item>
+            <item>item #2</item>
+            </list>
+        XML);
+    });
+    Route::get('txt', function () {
+        return "FooBar\nPingPong";
+    });
+    Route::get('yaml', function () {
+        return implode(PHP_EOL, [
+            'foo: key',
+            'ping: pong',
+            '',
+        ]);
+    });
+});
+
+test('html response body matches with snapshot')
+    ->get('/html')
+    ->assertMatchesHtmlSnapshot();
+
+test('json response body matches with snapshot')
+    ->get('/json')
+    ->assertMatchesJsonSnapshot();
+
+test('xml response body matches with snapshot')
+    ->get('/xml')
+    ->assertMatchesXmlSnapshot();
+
+test('txt response body matches with snapshot')
+    ->get('/txt')
+    ->assertMatchesTextSnapshot();
+
+test('yaml response body matches with snapshot')
+    ->get('/yaml')
+    ->assertMatchesSnapshot(new YamlDriver());

--- a/tests/__snapshots__/Laravel__html_response_body_matches_with_snapshot__1.html
+++ b/tests/__snapshots__/Laravel__html_response_body_matches_with_snapshot__1.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>title</title></head>
+<body><h1>first headline</h1></body>
+</html>

--- a/tests/__snapshots__/Laravel__json_response_body_matches_with_snapshot__1.json
+++ b/tests/__snapshots__/Laravel__json_response_body_matches_with_snapshot__1.json
@@ -1,0 +1,4 @@
+{
+    "foo": "bar",
+    "ping": "pong"
+}

--- a/tests/__snapshots__/Laravel__txt_response_body_matches_with_snapshot__1.txt
+++ b/tests/__snapshots__/Laravel__txt_response_body_matches_with_snapshot__1.txt
@@ -1,0 +1,2 @@
+FooBar
+PingPong

--- a/tests/__snapshots__/Laravel__xml_response_body_matches_with_snapshot__1.xml
+++ b/tests/__snapshots__/Laravel__xml_response_body_matches_with_snapshot__1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<list>
+  <item>item #1</item>
+  <item>item #2</item>
+</list>

--- a/tests/__snapshots__/Laravel__yaml_response_body_matches_with_snapshot__1.yml
+++ b/tests/__snapshots__/Laravel__yaml_response_body_matches_with_snapshot__1.yml
@@ -1,0 +1,2 @@
+foo: key
+ping: pong


### PR DESCRIPTION
based on https://github.com/pestphp/pest/pull/109
implementation of https://twitter.com/devgummibeer/status/1272090519120855042

This PR adds macros to the `\Illuminate\Testing\TestResponse` to allow chaining the snapshot assertions on the test response.

Before this PR you had to use `Closure` to call the assertion and had to do everything by hand.
```php
test('can render html', function() {
  $html = get('html')->getContent();
  assertMatchesHtmlSnapshot($html);
});
```

With this PR you can utilize the full beauty of pest by chaining all methods:
```php
get('html')->assertMatchesHtmlSnapshot();
```