### PR TITLE
feat: update to support Pest 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4",
-        "pestphp/pest": "^0.2",
+        "pestphp/pest": "^0.3",
         "spatie/phpunit-snapshot-assertions": "^4.2.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,10 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.3.x-dev"
+        }
+    }
 }

--- a/tests/Autoload.php
+++ b/tests/Autoload.php
@@ -1,7 +1,7 @@
 <?php
 
 it('autoloads function', function ($name) {
-    assertTrue(function_exists("\\Spatie\\Snapshots\\$name"));
+    expect(function_exists("\\Spatie\\Snapshots\\$name"))->toBeTrue();
 })->with([
     'assertMatchesSnapshot',
     'assertMatchesFileHashSnapshot',

--- a/tests/Functions.php
+++ b/tests/Functions.php
@@ -9,5 +9,5 @@ assertMatchesSnapshot('pending higher order tests');
 test('closure tests', function () {
     assertMatchesSnapshot('closure tests');
 
-    assertFileExists(__DIR__ . DIRECTORY_SEPARATOR . '__snapshots__');
+    expect(__DIR__ . DIRECTORY_SEPARATOR . '__snapshots__')->toBeDirectory();
 });


### PR DESCRIPTION
Looks like this is kind of dependent on https://github.com/pestphp/pest-plugin-coverage/pull/7 being merged (at least for the `test-coverage` script in Composer), but should work pass CI.

Once this PR is merged, I have another PR queued up for testing against PHP 8. 👍🏻