### PR TITLE
feat: store snapshot in the same directory as test

### DIFF
--- a/src/Concerns/SnapshotDirectoryAware.php
+++ b/src/Concerns/SnapshotDirectoryAware.php
@@ -13,9 +13,14 @@ trait SnapshotDirectoryAware
      */
     protected function getSnapshotDirectory(): string
     {
+        $dir = explode('Tests\\', static::class, 2)[1];
+
+        $dir = dirname(str_replace('\\', DIRECTORY_SEPARATOR, $dir));
+
         return implode(DIRECTORY_SEPARATOR, [
             TestSuite::getInstance()->rootPath,
             'tests',
+            $dir,
             '__snapshots__',
         ]);
     }

--- a/tests/Nested/Test.php
+++ b/tests/Nested/Test.php
@@ -1,0 +1,5 @@
+<?php
+
+use function Spatie\Snapshots\assertMatchesSnapshot;
+
+assertMatchesSnapshot('snapshot should be stored in the same directory as the test');

--- a/tests/Nested/__snapshots__/Test__assertMatchesSnapshot_snapshot_should_be_stored_in_e_test__1.txt
+++ b/tests/Nested/__snapshots__/Test__assertMatchesSnapshot_snapshot_should_be_stored_in_e_test__1.txt
@@ -1,0 +1,1 @@
+snapshot should be stored in the same directory as the test


### PR DESCRIPTION
Previously snapshots are always stored in `tests/__snapshots__` directory, even though the test file is in a nested directory.

This PR makes it that the snapshots are stored in the same directory as the test file, even in nested directory. This behavior is the same as the [underlying package](https://github.com/spatie/phpunit-snapshot-assertions).

Note: The [PEST documentation about snapshots](https://pestphp.com/docs/plugins/snapshots#assertMatchesSnapshot) might better be changed if this PR is approved.