### PR TITLE
fix: include dataset and remove prefix

### DIFF
--- a/src/Concerns/SnapshotIdAware.php
+++ b/src/Concerns/SnapshotIdAware.php
@@ -2,8 +2,10 @@
 
 namespace Spatie\Snapshots\Concerns;
 
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
+/** @mixin TestCase */
 trait SnapshotIdAware
 {
     /*
@@ -12,8 +14,11 @@ trait SnapshotIdAware
      */
     protected function getSnapshotId(): string
     {
-        return (new ReflectionClass($this))->getShortName().'__'.
-            str_replace(' ', '_', $this->name()).'__'.
-            $this->snapshotIncrementor;
+        return sprintf(
+            '%s__%s__%s',
+            (new ReflectionClass($this))->getShortName(),
+            str_replace(' ', '_', str_replace('__pest_evaluable_', '', $this->nameWithDataSet())),
+            $this->snapshotIncrementor
+        );
     }
 }


### PR DESCRIPTION
This removes the `__pest_evaluable_` prefix from snapshots (closes #15), and also ensures that the dataset is included in the file name.

The only issue is, PHPUnit changed the formatting of enums, so they now show as:
```diff
- CategoryTest__it_can_get_the_Category_from_Metadata_with_(AppEnumsMetadataType_Object_())_1__1
+ CategoryTest__it_can_get_the_Category_from_Metadata_with_data_set_(AppEnumsMetadataType_Enum_(Movie,_1))__1
```

Not sure why, but it seems to duplicate the `data set` wording when datasets are named.

```diff
- MetadataTest__it_can_get_the_Simkl_link_for_metadata_with_data_set_TMDb__1
+ MetadataTest__it_can_get_the_Simkl_link_for_metadata_with_data_set_data_set_TMDb__1
```

This seems to be because we prefix the named datasets with `data set`...