### PR TITLE
feat: put pest snapshots closer to tests

### DIFF
--- a/src/Concerns/SnapshotDirectoryAware.php
+++ b/src/Concerns/SnapshotDirectoryAware.php
@@ -13,10 +13,14 @@ trait SnapshotDirectoryAware
      */
     protected function getSnapshotDirectory(): string
     {
+        $testClass = TestSuite::getInstance()->test::class;
+        $testFile = str_replace('\\', DIRECTORY_SEPARATOR, explode('P\\', $testClass, limit: 2)[1]);
+
         return implode(DIRECTORY_SEPARATOR, [
             TestSuite::getInstance()->rootPath,
-            'tests',
+            dirname($testFile),
             '__snapshots__',
+            basename($testFile),
         ]);
     }
 }


### PR DESCRIPTION
Now all snapshots are stored in a root `__snapshots__` folder. This is improved with this PR by storing snapshots a `__snapshots__` directory next to the tests.

Example tree:

```
tests/
  __snapshots__/
    ExampleTest/
      snapshot.yml
  ExampleTest.php
```
