### PR TITLE
Fix duplicate Snapshost ID increment regression

### DIFF
--- a/src/Concerns/SnapshotIdAware.php
+++ b/src/Concerns/SnapshotIdAware.php
@@ -27,7 +27,6 @@ trait SnapshotIdAware
         if ($id !== null) {
             $suffix = 's-'.$id;
         } else {
-            $this->snapshotIncrementor++;
             $suffix = $this->snapshotIncrementor;
         }
 


### PR DESCRIPTION
Upgrading the following packages greatly broke snapshot testing, as all snapshots were shifted to start from `__2` instead of `__1` suffix:

- spatie/pest-plugin-snapshots v2.2.1 => 2.3.0
- spatie/phpunit-snapshot-assertions 5.3.0 => 5.3.2

You can simply reproduce this by running the tests of this package:

```bash
$ ./vendor/bin/pest

   WARN  Tests\Functions
  … higher order tests → Snapshot created for Functions__higher_order_tests__2                                                                                                                                                   0.01s  
  … assertMatchesSnapshot 'pending higher order tests' → Snapshot created for Functions__assertMatchesSnapshot__pending_higher_order_tests___2
  … closure tests → Snapshot created for Functions__closure_tests__2
  ✓ expectation test

$ git status

Untracked files:
	tests/__snapshots__/Functions__assertMatchesSnapshot__pending_higher_order_tests___2.txt
	tests/__snapshots__/Functions__closure_tests__2.txt
	tests/__snapshots__/Functions__higher_order_tests__2.txt
```

after applying this PR, the snapshot file names again match the previous snapshots, starting with `__1` suffixes:

```bash
$  ./vendor/bin/pest

   PASS  Tests\Functions
  ✓ higher order tests
  ✓ assertMatchesSnapshot 'pending higher order tests'
  ✓ closure tests
  ✓ expectation test
```

The extra increment in `SnapshotIdAware::getSnapshotId()` is redundant, as the `$snapshotIncrementor` is already incremented in [spatie/phpunit-snapshot-assertions v5.3.2 `src/MatchesSnapshots.php#L173`](https://github.com/spatie/phpunit-snapshot-assertions/blob/5.3.2/src/MatchesSnapshots.php#L173):

```php
    protected function resolveSnapshotId(?string $id = null): string
    {
        if ($id !== null) {
            return (new ReflectionClass($this))->getShortName().'__'.
                $this->nameWithDataSet().'__'.
                's-'.$id;
        }

        $this->snapshotIncrementor++;

        return $this->getSnapshotId();
    }
```

in other words:

`spatie/phpunit-snapshot-assertions` increments `$snapshotIncrementor` in `MatchesSnapshots::resolveSnapshotId()` before calling `getSnapshotId()`.
In `spatie/pest-plugin-snapshots` v2.3.0, the overridden `SnapshotIdAware::getSnapshotId()` also increments it, causing a double increment and making the first snapshot start at `_2`.
This PR removes the extra increment in the Pest override so numbering starts at `_1` again.